### PR TITLE
添加配置文件，添加python构建脚本用于跨平台构建，添加混淆key支持

### DIFF
--- a/Source/VSProj/ShuffleInstruction.cs
+++ b/Source/VSProj/ShuffleInstruction.cs
@@ -17,9 +17,13 @@ namespace IFix
 {
     public static class Program
     {
+        private static string ConfuseKey = string.Empty;
+
         static string[] Shuffle(string[] codes)
         {
-            Random r = new Random(DateTime.Now.Millisecond);
+            Random r = string.IsNullOrEmpty(ConfuseKey) ? 
+                        new Random(DateTime.Now.Millisecond) : new Random(ConfuseKey.GetHashCode() + 1);
+            
             for (int i = codes.Length - 1; i >= 0; i--)
             {
                 int cardIndex = r.Next(i);
@@ -35,6 +39,10 @@ namespace IFix
         static void Main(string[] args)
         {
             var des = args[1];
+
+            if (args.Length >= 3)
+                ConfuseKey = args[2];
+
             //已经生成了就不重新生成了
             if (File.Exists(des))
             {
@@ -73,7 +81,8 @@ namespace IFix
                 }
 
                 //生成随机的magic code
-                Random r = new Random(DateTime.Now.Millisecond);
+                Random r = string.IsNullOrEmpty(ConfuseKey) ?
+                            new Random(DateTime.Now.Millisecond) : new Random(ConfuseKey.GetHashCode());
                 ulong magic = (uint)r.Next();
                 magic = (magic << 32);
                 magic = magic | ((uint)r.Next());

--- a/Source/VSProj/build.py
+++ b/Source/VSProj/build.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+# -*- coding:utf-8 -*-
+
+import json
+import os
+import platform
+from shutil import copyfile
+
+
+def parse_global_config():
+    with open('config.json', 'r') as f:
+        content = f.read()
+        global_config = json.loads(content)
+
+        if 'windows' in platform.platform().lower():
+            global_config['gmcs'] = os.path.join(
+                global_config['UnityHome'], 'Editor/Data/Mono/bin/gmcs')
+            global_config['mono'] = os.path.join(
+                global_config['UnityHome'], 'Editor/Data/MonoBleedingEdge/bin/mono')
+        else:
+            global_config['gmcs'] = os.path.join(
+                global_config['UnityHome'], 'Contents/Mono/bin/gmcs')
+            global_config['mono'] = os.path.join(
+                global_config['UnityHome'], 'Contents/MonoBleedingEdge/bin/mono')
+
+        return global_config
+
+
+def main():
+    global_config = parse_global_config()
+
+    # 编译 ShuffleInstruction
+    os.system(
+        f"{global_config['gmcs']} ShuffleInstruction.cs -out:./ShuffleInstruction.exe")
+
+    # 生成混淆后的 Instruction.cs
+    os.system(
+        f"{global_config['mono']} ShuffleInstruction.exe Src/Core/Instruction.cs Instruction.cs {global_config['ConfuseKey']}")
+
+    # 构建 Dll
+    cmd_dll = f"{global_config['gmcs']} -define:UNITY_IPHONE -unsafe -target:library -out:{global_config['DllOutput']} Src/Builder/*.cs Src/Version.cs Instruction.cs \
+    Src/Core/AnonymousStorey.cs \
+    Src/Core/DataDefine.cs \
+    Src/Core/GenericDelegate.cs \
+    Src/Core/Il2CppSetOptionAttribute.cs \
+    Src/Core/ObjectClone.cs \
+    Src/Core/ReflectionMethodInvoker.cs \
+    Src/Core/StackOperation.cs \
+    Src/Core/SwitchFlags.cs \
+    Src/Core/Utils.cs \
+    Src/Core/VirtualMachine.cs \
+    Src/Core/WrappersManager.cs"
+    os.system(cmd_dll)
+
+    # 构建 Toolkit
+    if not os.path.exists(global_config['ToolKitOutput']):
+        os.mkdir(global_config['ToolKitOutput'])
+
+    cecil_files = os.listdir('ThirdParty')
+    for file in cecil_files:
+        if 'Mono.Cecil' in file:
+            copyfile(os.path.join('ThirdParty', file), os.path.join(
+                global_config['ToolKitOutput'], file))
+
+    cmd_tool = f"{global_config['gmcs']} -define:UNITY_IPHONE -unsafe -reference:ThirdParty/Mono.Cecil.dll,ThirdParty/Mono.Cecil.Mdb.dll,ThirdParty/Mono.Cecil.Pdb.dll -out:{global_config['ToolKitOutput']}/IFix.exe -debug Instruction.cs Src/Tools/*.cs Src/Version.cs"
+
+    os.system(cmd_tool)
+
+
+if __name__ == '__main__':
+    main()

--- a/Source/VSProj/build_for_unity.py
+++ b/Source/VSProj/build_for_unity.py
@@ -31,14 +31,14 @@ def main():
 
     # 编译 ShuffleInstruction
     os.system(
-        f"{global_config['gmcs']} ShuffleInstruction.cs -out:./ShuffleInstruction.exe")
+        "%s ShuffleInstruction.cs -out:./ShuffleInstruction.exe" % (global_config['gmcs']))
 
     # 生成混淆后的 Instruction.cs
     os.system(
-        f"{global_config['mono']} ShuffleInstruction.exe Src/Core/Instruction.cs Instruction.cs {global_config['ConfuseKey']}")
+        "%s ShuffleInstruction.exe Src/Core/Instruction.cs Instruction.cs %s" % (global_config['mono'], global_config['ConfuseKey']))
 
     # 构建 Dll
-    cmd_dll = f"{global_config['gmcs']} -define:UNITY_IPHONE -unsafe -target:library -out:{global_config['DllOutput']} Src/Builder/*.cs Src/Version.cs Instruction.cs \
+    cmd_dll = "%s -define:UNITY_IPHONE -unsafe -target:library -out:%s Src/Builder/*.cs Src/Version.cs Instruction.cs \
     Src/Core/AnonymousStorey.cs \
     Src/Core/DataDefine.cs \
     Src/Core/GenericDelegate.cs \
@@ -49,7 +49,7 @@ def main():
     Src/Core/SwitchFlags.cs \
     Src/Core/Utils.cs \
     Src/Core/VirtualMachine.cs \
-    Src/Core/WrappersManager.cs"
+    Src/Core/WrappersManager.cs" % (global_config['gmcs'], global_config['DllOutput'])
     os.system(cmd_dll)
 
     # 构建 Toolkit
@@ -62,7 +62,7 @@ def main():
             copyfile(os.path.join('ThirdParty', file), os.path.join(
                 global_config['ToolKitOutput'], file))
 
-    cmd_tool = f"{global_config['gmcs']} -define:UNITY_IPHONE -unsafe -reference:ThirdParty/Mono.Cecil.dll,ThirdParty/Mono.Cecil.Mdb.dll,ThirdParty/Mono.Cecil.Pdb.dll -out:{global_config['ToolKitOutput']}/IFix.exe -debug Instruction.cs Src/Tools/*.cs Src/Version.cs"
+    cmd_tool = "%s -define:UNITY_IPHONE -unsafe -reference:ThirdParty/Mono.Cecil.dll,ThirdParty/Mono.Cecil.Mdb.dll,ThirdParty/Mono.Cecil.Pdb.dll -out:%s/IFix.exe -debug Instruction.cs Src/Tools/*.cs Src/Version.cs" % (global_config['gmcs'], global_config['ToolKitOutput'])
 
     os.system(cmd_tool)
 

--- a/Source/VSProj/config.json
+++ b/Source/VSProj/config.json
@@ -1,0 +1,6 @@
+{
+    "UnityHome": "/Applications/Unity2017/Unity.app",
+    "DllOutput": "../UnityProj/Assets/Plugins/IFix.Core.dll",
+    "ToolKitOutput": "../UnityProj/IFixToolKit",
+    "ConfuseKey": ""
+}


### PR DESCRIPTION
1. 添加构建配置文件
2. 添加 Python 构建脚本，支持跨平台
3. 添加混淆 key ，resolve #6 