### PR TITLE
[Change] 

### DIFF
--- a/Source/UnityProj/Assets/IFix/Editor/ILFixEditor.cs
+++ b/Source/UnityProj/Assets/IFix/Editor/ILFixEditor.cs
@@ -63,7 +63,7 @@ namespace IFix.Editor
         const string TIMESTAMP_FORMAT = "yyyyMMddHHmmss";
 
         //注入的目标文件夹
-        private static string _targetScriptAssembliesFolder = "";
+        private static string targetAssembliesFolder = "";
 
         //system("mono ifix.exe [args]")
         public static void CallIFix(List<string> args)
@@ -261,7 +261,7 @@ namespace IFix.Editor
             {
 
                 var core_path = "./Assets/Plugins/IFix.Core.dll";
-                var assembly_path = string.Format("./Library/{0}/{1}.dll", _targetScriptAssembliesFolder, assembly);
+                var assembly_path = string.Format("./Library/{0}/{1}.dll", targetAssembliesFolder, assembly);
                 var patch_path = string.Format("./{0}.ill.bytes", assembly);
                 List<string> args = new List<string>() { "-inject", core_path, assembly_path,
                     processCfgPath, patch_path, assembly_path };
@@ -294,7 +294,7 @@ namespace IFix.Editor
                 return;
             }
 
-            _targetScriptAssembliesFolder = GetScriptAssembliesFolder();
+            targetAssembliesFolder = GetScriptAssembliesFolder();
 
             foreach (var assembly in injectAssemblys)
             {
@@ -335,7 +335,7 @@ namespace IFix.Editor
                 Directory.CreateDirectory(BACKUP_PATH);
             }
 
-            var scriptAssembliesDir = string.Format("./Library/{0}/", _targetScriptAssembliesFolder);
+            var scriptAssembliesDir = string.Format("./Library/{0}/", targetAssembliesFolder);
 
             foreach (var assembly in injectAssemblys)
             {
@@ -366,7 +366,7 @@ namespace IFix.Editor
         /// <param name="ts">时间戳</param>
         static void doRestore(string ts)
         {
-            var scriptAssembliesDir = string.Format("./Library/{0}/", _targetScriptAssembliesFolder);
+            var scriptAssembliesDir = string.Format("./Library/{0}/", targetAssembliesFolder);
 
             foreach (var assembly in injectAssemblys)
             {
@@ -787,7 +787,6 @@ namespace IFix.Editor
                 foreach (var assembly in injectAssemblys)
                 {
                     var assembly_path = string.Format("./Library/{0}/{1}.dll", GetScriptAssembliesFolder(), assembly);
-                    UnityEngine.Debug.Log(assembly_path);
                     GenPatch(assembly, assembly_path, "./Assets/Plugins/IFix.Core.dll",
                         string.Format("{0}.patch.bytes", assembly));
                 }

--- a/Source/UnityProj/Assets/IFix/Editor/ILFixEditor.cs
+++ b/Source/UnityProj/Assets/IFix/Editor/ILFixEditor.cs
@@ -62,6 +62,9 @@ namespace IFix.Editor
         //备份文件的时间戳生成格式
         const string TIMESTAMP_FORMAT = "yyyyMMddHHmmss";
 
+        //注入的目标文件夹
+        private static string _targetScriptAssembliesFolder = "";
+
         //system("mono ifix.exe [args]")
         public static void CallIFix(List<string> args)
         {
@@ -258,7 +261,7 @@ namespace IFix.Editor
             {
 
                 var core_path = "./Assets/Plugins/IFix.Core.dll";
-                var assembly_path = string.Format("./Library/ScriptAssemblies/{0}.dll", assembly);
+                var assembly_path = string.Format("./Library/{0}/{1}.dll", _targetScriptAssembliesFolder, assembly);
                 var patch_path = string.Format("./{0}.ill.bytes", assembly);
                 List<string> args = new List<string>() { "-inject", core_path, assembly_path,
                     processCfgPath, patch_path, assembly_path };
@@ -291,6 +294,8 @@ namespace IFix.Editor
                 return;
             }
 
+            _targetScriptAssembliesFolder = GetScriptAssembliesFolder();
+
             foreach (var assembly in injectAssemblys)
             {
                 InjectAssembly(assembly);
@@ -299,6 +304,16 @@ namespace IFix.Editor
             //doBackup(DateTime.Now.ToString(TIMESTAMP_FORMAT));
 
             AssetDatabase.Refresh();
+        }
+
+        private static string GetScriptAssembliesFolder()
+        {
+            var assembliesFolder = "PlayerScriptAssemblies";
+            if (!Directory.Exists(string.Format("./Library/{0}/", assembliesFolder)))
+            {
+                assembliesFolder = "ScriptAssemblies";
+            }
+            return assembliesFolder;
         }
 
         //默认的注入及备份程序集
@@ -320,7 +335,7 @@ namespace IFix.Editor
                 Directory.CreateDirectory(BACKUP_PATH);
             }
 
-            var scriptAssembliesDir = "./Library/ScriptAssemblies/";
+            var scriptAssembliesDir = string.Format("./Library/{0}/", _targetScriptAssembliesFolder);
 
             foreach (var assembly in injectAssemblys)
             {
@@ -351,7 +366,7 @@ namespace IFix.Editor
         /// <param name="ts">时间戳</param>
         static void doRestore(string ts)
         {
-            var scriptAssembliesDir = "./Library/ScriptAssemblies/";
+            var scriptAssembliesDir = string.Format("./Library/{0}/", _targetScriptAssembliesFolder);
 
             foreach (var assembly in injectAssemblys)
             {
@@ -771,8 +786,10 @@ namespace IFix.Editor
             {
                 foreach (var assembly in injectAssemblys)
                 {
-                    GenPatch(assembly, string.Format("./Library/ScriptAssemblies/{0}.dll", assembly),
-                        "./Assets/Plugins/IFix.Core.dll", string.Format("{0}.patch.bytes", assembly));
+                    var assembly_path = string.Format("./Library/{0}/{1}.dll", GetScriptAssembliesFolder(), assembly);
+                    UnityEngine.Debug.Log(assembly_path);
+                    GenPatch(assembly, assembly_path, "./Assets/Plugins/IFix.Core.dll",
+                        string.Format("{0}.patch.bytes", assembly));
                 }
             }
             catch (Exception e)


### PR DESCRIPTION
适配因为Unity2019.2.15f1打包流程修改而造成的问题，注入的Assembly文件夹先检测PlayerScriptAssemblies是否存在（新版Unity打包时会生成这个临时文件夹），不存在再处理ScriptAssemblies文件夹下的内容（Editor状态下也是注入该文件夹）