### PR TITLE
[fixbug] CustomBridge 注入跨dll的delegate，InjectFix 时报错。

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -3195,7 +3195,7 @@ namespace IFix
                     }
                     else
                     {
-                        getWrapperMethod(wrapperType, anonObjOfWrapper, invoke, true, true);
+                        getWrapperMethod(wrapperType, anonObjOfWrapper, invoke.TryImport(t.Module), true, true);
                     }
                 }
                 else if (td.IsInterface)


### PR DESCRIPTION
错误例子：
```c#
// 一个dll里定义这个
public delegate void TestDelegate(bool add);
```
```c#
// 另外一个dll，引用上面的TestDelegate
    [IFix.CustomBridge]
    public static class AdditionalBridge
    {
        static List<Type> bridge = new List<Type>()
        {
            typeof(TestDelegate),
        };
    }
```

Inject下面的dll时会报错：`Unhandled Exception:System.ArgumentException: Member 'System.Boolean' is declared in another module and needs to be imported`