### PR TITLE
解决 新类子类重写父类函数时base关键字后还有语句并未走到的问题 fix https://github.com/Tencent/Inje…

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -1047,13 +1047,17 @@ namespace IFix
             }
             if (methodToId.ContainsKey(callee))
             {
-                if (isCallvirt && virtualMethodToIndex.ContainsKey(callee))
+                if (isCallvirt)
                 {
-                    return new MethodIdInfo()
+                    getVirtualMethodForType(method.DeclaringType);
+                    if (virtualMethodToIndex.ContainsKey(callee))
                     {
-                        Id = virtualMethodToIndex[callee],
-                        Type = CallType.InteralVirtual
-                    };
+                        return new MethodIdInfo()
+                        {
+                            Id = virtualMethodToIndex[callee],
+                            Type = CallType.InteralVirtual
+                        };
+                    }
                 }
                 return new MethodIdInfo()
                 {


### PR DESCRIPTION
…ctFix/issues/161