### PR TITLE
泛型报错时输出更多log信息

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -166,7 +166,13 @@ namespace IFix
             if (type.IsRequiredModifier) return addExternType((type as RequiredModifierType).ElementType, contextType);
             if (type.IsGenericParameter || type.HasGenericArgumentFromMethod())
             {
-                throw new InvalidProgramException("try to use a generic type definition: " + type);
+                var genericTypeInfo = "{None}";
+                try {
+                    var genericType = (GenericParameter)type;
+                    var owner = (TypeDefinition)genericType.Owner;
+                    genericTypeInfo = $"{{Owner:{owner.FullName}, Scope:{genericType.Scope.Name}}}";
+                } catch { }
+                throw new InvalidProgramException("try to use a generic type definition: " + type + ", generic type info: " + genericTypeInfo);
             }
             if (externTypeToId.ContainsKey(type))
             {


### PR DESCRIPTION
这个地方大部分报错都是try to use a generic type definition:  T，压根不知道这个T是哪个，要Patch标签删来删去一个个找。加入了log出该泛型的更多信息，方便使用