### PR TITLE
Init `out struct` parameters to prevent NullReferenceReference

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -1261,6 +1261,26 @@ namespace IFix
                     }
                 }
 
+                //修复out struct问题
+                for (int i = 0; i < method.Parameters.Count; i++)
+                {
+                    var parameter = method.Parameters[i];
+                    if (parameter.IsOut && parameter.ParameterType.GetElementType().IsValueType && !parameter.ParameterType.GetElementType().IsPrimitive)
+                    {
+                        code.Add(new Core.Instruction
+                        {
+                            Code = Core.Code.Ldarg,
+                            Operand = i + (method.HasThis ? 1 : 0)
+                        });
+                        code.Add(new Core.Instruction
+                        {
+                            Code = Core.Code.Initobj,
+                            Operand = addExternType(parameter.ParameterType.GetElementType())
+                        });
+                        offsetAdd += 2;
+                    }
+                }
+
                 if (offsetAdd > 0)
                 {
                     var ilNewOffset = new Dictionary<Instruction, int>();


### PR DESCRIPTION
Reason:

https://github.com/Tencent/InjectFix/blob/552da3654e74c4b08bbe2533699fb2306df5de7e/Source/VSProj/Src/Core/StackOperation.cs#L256-L260

Known issue, but never fixed😅

Test case:

``` csharp
        public struct TestStruct
        {
            public int a;
            public string b;
        }

        [Patch]
        public void TestOutStruct(out TestStruct ts)
        {
            ts.a = 114514;
            ts.b = "buggy IFix";
        }
```