### PR TITLE
Fix field type collection when meeting T[] or Generic<T> fields

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -3859,6 +3859,13 @@ namespace IFix
                 for (int i = 0; i < fields.Count; i++)
                 {
                     var fieldType = fields[i].FieldType;
+
+                    if (fieldType.IsArray || fieldType.IsGenericInstance)
+                    {
+                        addExternType(fieldType, fields[i].DeclaringType);
+                        continue;
+                    }
+
                     if (fieldType.IsGenericParameter)
                     {
                         var resolveType = ((GenericParameter)fieldType).ResolveGenericArgument(fields[i].DeclaringType);


### PR DESCRIPTION
The commit 9d8e950 is an uncomplete fix due to lack consideration of array and generic instance type fields in a generic class. This commit will get it fixed.

Can be examined with this code:
``` csharp
abstract class Generic<T>
{
  T[] Field1;
  List<T> Field2;
}

class GenericString : Generic<string>
{
  [IFix.Patch]
  public void Test()
  {
    Field1 = new string[] {"Test"};
    Field2 = new List<string> {"Test"};
    Debug.Log(Field1[0]);
    Debug.Log(Field2[0]);
  }
}

```

