### PR TITLE
Fix event add/remove, Fix #149

### DIFF
--- a/Source/VSProj/Src/Tools/CodeTranslator.cs
+++ b/Source/VSProj/Src/Tools/CodeTranslator.cs
@@ -1137,6 +1137,15 @@ namespace IFix
                 };
             }
 
+            if (method.IsSpecialName && (method.IsAddOn || method.IsRemoveOn || method.IsGetter || method.IsSetter) && !isNewMethod(method) && !isNewClass(method.DeclaringType) && isCompilerGenerated(method))
+            {
+                return new MethodIdInfo()
+                {
+                    Id = addExternMethod(callee, caller),
+                    Type = CallType.Extern
+                };
+            }
+
             if (method.Parameters.Any(p => p.ParameterType.IsPointer) || method.ReturnType.IsPointer)
             {
                 Console.WriteLine("Warning: unsafe method, " + method + " in " + method.DeclaringType);


### PR DESCRIPTION
This PR fixes #149 .

``` csharp
event Action iFix;

[IFix.Patch]
public void Test() {
	Action bug = () => Debug.Log("Full of bugs");
	iFix += bug;
}
```

Expect:
Nothing was wrong.

Actual:
`ExecutionEngineException: Attempting to call method 'System.Threading.Interlocked::CompareExchange<...>' for which no ahead of time (AOT) code was generated.`

Wrong explaination:
![image](https://github.com/user-attachments/assets/4035d715-47d9-4913-a81e-3631dab017b9)

Correct explaination:
![image](https://github.com/user-attachments/assets/294a2aff-55f0-47e6-be45-cf0e8d5d9b1c)

**By using, referring or merging this pull request, you understand and agree that the copyright or patent license of this pull request and its code will not be granted to Tencent.**